### PR TITLE
Fix build problem with dex file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,6 +41,7 @@ android {
         applicationId "com.example.grocery_app"
         minSdkVersion 16
         targetSdkVersion 28
+        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -64,6 +65,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'com.android.support:multidex:1.0.3'
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Fix the problem that occurred during every build due to the use of
google services. It produced the following error:

`D8: Cannot fit requested classes in a single dex file (# methods: 85227 > 65536)`